### PR TITLE
fix(items): remove unused chars from string

### DIFF
--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -50,6 +50,7 @@ void SaveRegisteredItems()
 		sprintf(&itemstring[2*i], "%02x", bits[i]);
 	}
 	itemstring[2*i] = '\0';
+    itemstring[128] = '\0';
 
 //	Com_Printf("ItemString: %s\n", itemstring);
 


### PR DESCRIPTION
The registered items string is longer than necessary because the MAX_ITEMS value is incorrect. This PR is a quick bandage to truncate the string.